### PR TITLE
Dump CDS cache on all Java installations

### DIFF
--- a/installer-jessie.sh
+++ b/installer-jessie.sh
@@ -190,9 +190,6 @@ function java_install_jri() {
 
     JAVA_REAL_EXE="$(which java)"
     CLASSLIST="$JRI_CLASSLIST"
-
-    write_log "dumping java cds"
-    "$JAVA_REAL_EXE" -Xshare:dump
     return $?
 }
 
@@ -257,6 +254,9 @@ function do_fixup_perms() {
 ######################
 # Print Java version
 function print_java() {
+    write_log "dumping cds cache"
+    "$JAVA_REAL_EXE" -Xshare:dump
+
     echo
     echo "-> Java version:"
     "$JAVA_REAL_EXE" -version

--- a/installer.sh
+++ b/installer.sh
@@ -233,6 +233,9 @@ function do_fixup_perms() {
 ######################
 # Print Java version
 function print_java() {
+    write_log "dumping cds cache"
+    "$JAVA_REAL_EXE" -Xshare:dump
+
     echo
     echo "-> Java version:"
     "$JAVA_REAL_EXE" -version


### PR DESCRIPTION
This ensures that the CDS cache is generated everywhere. It seems that on Raspbian this wasn't the case.

This is probably not necessary on EV3 with JRI, but this change does it even there, to be extra-sure.